### PR TITLE
Add missing CMakeLists.txt file necessary for integration with fp-bench

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,2 @@
+add_subdirectory(real)
+add_subdirectory(syn)


### PR DESCRIPTION
This is necessary for this repository to be dropped into `fp-bench` as a folder named `aachen.
