### PR TITLE
Avoid compiler hang when using Clang 3.4.2 and building with optimizations.

### DIFF
--- a/real/CMakeLists.txt
+++ b/real/CMakeLists.txt
@@ -4,3 +4,16 @@ add_benchmark(numerical_recipes)
 add_benchmark(libmatheval)
 add_benchmark(diction)
 add_benchmark(units)
+
+# HACK: Disable optimizing this benchmark when using old Clang because Clang 3.4.2
+# hangs when trying to optimize this benchmark.
+if (ENABLE_TARGET_UNITS_METER_FT)
+  if ("${CMAKE_C_COMPILER_ID}" MATCHES "Clang")
+    if (${CMAKE_C_COMPILER_VERSION} VERSION_LESS "3.5")
+      set(TARGET_TO_NOT_OPTIMIZE units_meter_ft.x86_64)
+      message(WARNING "Detected you using Clang ${CMAKE_C_COMPILER_VERSION}."
+        "Disabling optimizations for ${TARGET_TO_NOT_OPTIMIZE} to avoid compiler hang")
+      target_compile_options(${TARGET_TO_NOT_OPTIMIZE} PRIVATE -O0)
+    endif()
+  endif()
+endif()


### PR DESCRIPTION
Clang 3.4.2 hangs when trying to compile the
`real/units/units-2.13/parse.tab.c` when optimizations are enabled.

The problem seems to be that the SROA pass gets stucks in an infinite
loop in Clang when compiling the `unitsparse` function. Unfortunately
`__attribute__((optnone))` was not available in Clang 3.4.2 so
instead we add a little hack to the build system to force Clang to
build this particular benchmarks without optimizations regardless
of how CMAKE_BUILD_TYPE is set.
