### PR TITLE
Disable `raise()` in GMP due it causing KLEE to kill itself.

### DIFF
--- a/real/gmp/benchmarks/gmp-6.1.1/invalid.c
+++ b/real/gmp/benchmarks/gmp-6.1.1/invalid.c
@@ -78,6 +78,6 @@ see https://www.gnu.org/licenses/.  */
 void
 __gmp_invalid_operation (void)
 {
-  raise (SIGFPE);
+  // raise (SIGFPE); // DSL: Disabled due to crashing KLEE
   abort ();
 }


### PR DESCRIPTION
Disable `raise()` in GMP due it causing KLEE to kill itself. All we want to do is reach the `abort()` call.

This fixes issue #4 (
https://github.com/danielschemmel/fp-benchmarks-aachen/issues/4 )