### PR TITLE
When building GMP propagate CMAKE_C_FLAGS and CMAKE_CXX_FLAGS into the build

### DIFF
--- a/real/gmp/CMakeLists.txt
+++ b/real/gmp/CMakeLists.txt
@@ -42,8 +42,8 @@ if (DEFINED CMAKE_CONFIGURATION_TYPES)
 endif()
 
 string(TOUPPER "${CMAKE_BUILD_TYPE}" CMAKE_BUILD_TYPE_UPPER)
-set(GMP_CFLAGS "${CMAKE_C_FLAGS_${CMAKE_BUILD_TYPE_UPPER}}")
-set(GMP_CXXFLAGS "${CMAKE_CXX_FLAGS_${CMAKE_BUILD_TYPE_UPPER}}")
+set(GMP_CFLAGS "${CMAKE_C_FLAGS_${CMAKE_BUILD_TYPE_UPPER}} ${CMAKE_C_FLAGS}")
+set(GMP_CXXFLAGS "${CMAKE_CXX_FLAGS_${CMAKE_BUILD_TYPE_UPPER}} ${CMAKE_CXX_FLAGS}")
 # Generate a script to invoke the configure script so we can pass environment variables.
 set(AUTOGEN_MESSAGE "Automatically generated. DO NOT EDIT!")
 set(configure_script "${CMAKE_CURRENT_SOURCE_DIR}/benchmarks/gmp-6.1.1/configure")


### PR DESCRIPTION
When building GMP propagate CMAKE_C_FLAGS and CMAKE_CXX_FLAGS into the build

The motivation behind this change is to propagte the `--coverage`
flag into the build when the fp-bench infrastructure is using it.

You'll probably want to test this. I've only done limited testing so far. It worked fine for gcc but for wllvm using clang I've not tested properly because I need to recompile my build of clang. You have to build compiler-rt to get the profiling runtime and I forgot to do that so I get linking errors when using the `--coverage` flag.

Note the gcov coverage files don't end up next the executable. Instead they appear next to the corresponding object files at runtime.

To use this pass `-DBUILD_WITH_PROFILING=ON` to cmake using the latest fp-bench infrastructure.