### PR TITLE
Fix typo in `syn/mod_longdouble` double benchmark. It wasn't actually

### DIFF
--- a/syn/mod/test.c
+++ b/syn/mod/test.c
@@ -83,7 +83,7 @@ int main(int argc, char** argv) {
 		printf("sizeof(long double): %zu\n", sizeof(long double));
 		puts("");
 
-		double f = 131, g = 331;
+		long double f = 131, g = 331;
 		test(f, g);
 
 		#if defined(USE_KLEE)


### PR DESCRIPTION
Fix typo in `syn/mod_longdouble` double benchmark. It wasn't actually testing long double.