### PR TITLE
Add missing call to `test()`. The sqrt was being computed but wasn't being used

### DIFF
--- a/syn/nan/test.c
+++ b/syn/nan/test.c
@@ -142,6 +142,7 @@ int main(int argc, char** argv) {
 		klee_make_symbolic(&f, sizeof(f), "f");
 		klee_assume(f < 0);
 		f = sqrtf(f);
+		test(f);
 		#endif
 	}
 #endif


### PR DESCRIPTION
Fix missing sqrt test