### PR TITLE
Partially fix `units_meter_ft.x86_64`

### DIFF
--- a/real/CMakeLists.txt
+++ b/real/CMakeLists.txt
@@ -7,10 +7,16 @@ add_benchmark(units)
 
 # HACK: Disable optimizing this benchmark when using old Clang because Clang 3.4.2
 # hangs when trying to optimize this benchmark.
-if (ENABLE_TARGET_UNITS_METER_FT)
-  if ("${CMAKE_C_COMPILER_ID}" MATCHES "Clang")
-    if (${CMAKE_C_COMPILER_VERSION} VERSION_LESS "3.5")
+if ("${CMAKE_C_COMPILER_ID}" MATCHES "Clang")
+  if (${CMAKE_C_COMPILER_VERSION} VERSION_LESS "3.5")
+    if (ENABLE_TARGET_UNITS_METER_FT)
       set(TARGET_TO_NOT_OPTIMIZE units_meter_ft.x86_64)
+      message(WARNING "Detected you using Clang ${CMAKE_C_COMPILER_VERSION}."
+        "Disabling optimizations for ${TARGET_TO_NOT_OPTIMIZE} to avoid compiler hang")
+      target_compile_options(${TARGET_TO_NOT_OPTIMIZE} PRIVATE -O0)
+    endif()
+    if (ENABLE_TARGET_UNITS_METER_FT_NON_KLEE)
+      set(TARGET_TO_NOT_OPTIMIZE units_meter_ft_non_klee.x86_64)
       message(WARNING "Detected you using Clang ${CMAKE_C_COMPILER_VERSION}."
         "Disabling optimizations for ${TARGET_TO_NOT_OPTIMIZE} to avoid compiler hang")
       target_compile_options(${TARGET_TO_NOT_OPTIMIZE} PRIVATE -O0)

--- a/real/units/spec.yml
+++ b/real/units/spec.yml
@@ -2,7 +2,6 @@ architectures:
   - x86_64
 categories:
   - real_world
-  - issta_2017
   - aachen
 dependencies:
   cmath: {}
@@ -30,19 +29,28 @@ defines:
   HAVE_INTTYPES_H: '1'
   HAVE_STDINT_H: '1'
   HAVE_UNISTD_H: '1'
+description: >
+  Convert from a symbolic number of meters to feet
 sources:
   - units-2.13/units.c
   - units-2.13/parse.tab.c
   - units-2.13/getopt.c
   - units-2.13/getopt1.c
+runtime_environment:
+  command_line_arguments: []
+  environment_variables:
+    'UNITSFILE': '@spec_dir@units-2.13/definitions.units'
 variants:
   meter_ft:
+    categories:
+      - issta_2017
+    defines:
+      KLEE: null
     dependencies:
       klee_runtime: {}
-    description: >
-      Convert from a symbolic number of meters to feet
-    verification_tasks:
-      no_assert_fail:
-        correct: true
-description: >
-  A tool to convert between units
+  # For testing
+  meter_ft_non_klee:
+    description: "Just for testing"
+verification_tasks:
+  no_assert_fail:
+    correct: true

--- a/real/units/units-2.13/units.c
+++ b/real/units/units-2.13/units.c
@@ -5626,11 +5626,11 @@ main(int argc, char **argv)
    }
 #endif
 
-#ifndef KLEE
-   // KLEE doesn't support this
-   signal(SIGINT, write_files_sig);
-   signal(SIGTERM, write_files_sig);
-#endif
+// DL: Disable for now. KLEE doesn't support this
+// and we would like to run both non_klee and symbolic
+// version through KLEE.
+//   signal(SIGINT, write_files_sig);
+//   signal(SIGTERM, write_files_sig);
 
    if (logfilename) {
      if (!interactive)

--- a/real/units/units-2.13/units.c
+++ b/real/units/units-2.13/units.c
@@ -42,7 +42,9 @@
 #include <signal.h>
 #include <stdarg.h>
 #include <time.h>
+#if defined(KLEE)
 #include <klee/klee.h>
+#endif
 
 #ifndef NO_SETLOCALE
 #  include<locale.h>
@@ -5518,39 +5520,28 @@ write_files_sig(int sig)
 int
 main(int argc, char **argv)
 {
-   argc = 5;
-	 argv = malloc(6*sizeof(char*));
-	 argv[0] = malloc(6);
-	 argv[0][0] = 'u';
-	 argv[0][1] = 'n';
-	 argv[0][2] = 'i';
-	 argv[0][3] = 't';
-	 argv[0][4] = 's';
-	 argv[0][5] = '\0';
-	 argv[1] = malloc(3);
-	 argv[1][0] = '-';
-	 argv[1][1] = 'f';
-	 argv[1][2] = '\0';
-	 argv[2] = malloc(8);
-	 argv[2][0] = '~';
-	 argv[2][1] = 'u';
-	 argv[2][2] = 'n';
-	 argv[2][3] = 'i';
-	 argv[2][4] = 't';
-	 argv[2][5] = '.';
-	 argv[2][6] = 'd';
-	 argv[2][7] = '\0';
-	 argv[3] = malloc(3);
-	 klee_make_symbolic(argv[3], 3, "argv[3]");
-   klee_assume(argv[3][0] >= '0');
-   klee_assume(argv[3][0] <= '9');
-   klee_assume(argv[3][1] == 'm');
-	 argv[3][2] = '\0';
-	 argv[4] = malloc(3);
-	 argv[4][0] = 'f';
-	 argv[4][1] = 't';
-	 argv[4][2] = '\0';
-	 argv[5] = 0;
+#if defined(KLEE)
+  argc = 3;
+  argv = malloc(4 * sizeof(char *));
+  argv[0] = malloc(6);
+  argv[0][0] = 'u';
+  argv[0][1] = 'n';
+  argv[0][2] = 'i';
+  argv[0][3] = 't';
+  argv[0][4] = 's';
+  argv[0][5] = '\0';
+  argv[1] = malloc(3);
+  klee_make_symbolic(argv[1], 3, "argv[1]");
+  klee_assume(argv[1][0] >= '0');
+  klee_assume(argv[1][0] <= '9');
+  klee_assume(argv[1][1] == 'm');
+  argv[1][2] = '\0';
+  argv[2] = malloc(3);
+  argv[2][0] = 'f';
+  argv[2][1] = 't';
+  argv[2][2] = '\0';
+  argv[3] = 0;
+#endif
 
    static struct unittype have, want;
    char *havestr=0, *wantstr=0;
@@ -5635,8 +5626,11 @@ main(int argc, char **argv)
    }
 #endif
 
+#ifndef KLEE
+   // KLEE doesn't support this
    signal(SIGINT, write_files_sig);
    signal(SIGTERM, write_files_sig);
+#endif
 
    if (logfilename) {
      if (!interactive)

--- a/real/units/units-2.13/units.c
+++ b/real/units/units-2.13/units.c
@@ -5531,7 +5531,7 @@ main(int argc, char **argv)
 	 argv[1][0] = '-';
 	 argv[1][1] = 'f';
 	 argv[1][2] = '\0';
-	 argv[2] = malloc(3);
+	 argv[2] = malloc(8);
 	 argv[2][0] = '~';
 	 argv[2][1] = 'u';
 	 argv[2][2] = 'n';

--- a/real/units/units-2.13/units.c
+++ b/real/units/units-2.13/units.c
@@ -5541,7 +5541,7 @@ main(int argc, char **argv)
 	 argv[2][6] = 'd';
 	 argv[2][7] = '\0';
 	 argv[3] = malloc(3);
-	 klee_make_symbolic(argv[1], 3, "argv[1]");
+	 klee_make_symbolic(argv[3], 3, "argv[3]");
    klee_assume(argv[3][0] >= '0');
    klee_assume(argv[3][0] <= '9');
    klee_assume(argv[3][1] == 'm');


### PR DESCRIPTION
There are some mistakes in this benchmark. I'm not sure how it ever worked for you before.

This is only a partial fix.

When I run it now I get

```
units: cannot open units file '~unit.d'.  No such file or directory
```

`~unit.d` seems to be a command line argument. Please accept this PR and then fix this so the benchmark works as intended.