### PR TITLE
Fix compilation of completely broken wxpro benchmark.

### DIFF
--- a/real/wxpro/main.c
+++ b/real/wxpro/main.c
@@ -1,7 +1,7 @@
 #include <assert.h>
 #include <stdlib.h>
 #include <klee/klee.h>
-#include "wxpro/units.h"
+#include "units.h"
 
 int main(int argc, char** argv) {
   double m;

--- a/real/wxpro/spec.yml
+++ b/real/wxpro/spec.yml
@@ -11,7 +11,7 @@ name: wxpro
 schema_version: 0
 sources:
   - main.c
-  - wxpro/units.c
+  - units.c
 variants:
   meter_ft:
     dependencies:

--- a/real/wxpro/units.c
+++ b/real/wxpro/units.c
@@ -1,6 +1,7 @@
 #include "units.h"
 #include <math.h>
 #include <stdio.h>
+#include <stdlib.h> // AACHEN: For malloc()
 
 // Wind Conversion
 
@@ -118,21 +119,23 @@ double frac( double num )
    return a;
 }
 
+// AACHEN: Function signature changed to avoid returning std::string.
+// Change usage of `bool` for C.
 char* DecimalLatitudeToLORAN( double decimalDegrees )
 {
    char* buf = malloc(16);
    char cardinal;
 
-   bool negative = false;
+   _Bool negative = 0/*false*/;
    if ( decimalDegrees < 0 )
-      negative = true;
+      negative = 1/*true*/;
    decimalDegrees = fabs( decimalDegrees );
 
    int degrees = (int)(decimalDegrees);
    int minutes = (int)((((decimalDegrees - degrees) * 100)*60.0)/100.0);
    int decimalMin = ((int)(((decimalDegrees - degrees) * 100)*60.0) - minutes * 100);
 
-   if ( negative == true )
+   if (negative)
       cardinal = 'S';
    else
       cardinal = 'N';
@@ -141,21 +144,23 @@ char* DecimalLatitudeToLORAN( double decimalDegrees )
    return buf;
 }
 
+// AACHEN: Function signature changed to avoid returning std::string.
+// Change usage of `bool` for C.
 char* DecimalLongitudeToLORAN( double decimalDegrees )
 {
    char* buf = malloc(16);
    char cardinal;
 
-   bool negative = false;
+   _Bool negative = 0/*false*/;
    if ( decimalDegrees < 0 )
-      negative = true;
+      negative = 1/*true*/;
    decimalDegrees = fabs( decimalDegrees );
 
    int degrees = (int)(decimalDegrees);
    int minutes = (int)((((decimalDegrees - degrees) * 100)*60.0)/100.0);
    int decimalMin = ((int)(((decimalDegrees - degrees) * 100)*60.0) - minutes * 100);
 
-   if ( negative == true )
+   if (negative)
       cardinal = 'W';
    else
       cardinal = 'E';

--- a/real/wxpro/units.h
+++ b/real/wxpro/units.h
@@ -1,0 +1,111 @@
+#ifndef __UNITS_H__
+#define __UNITS_H__
+#include <time.h>
+// AACHEN: Removed to avoid std::string usage.
+//#include <string>
+
+#define JAN12000 (946684800)
+
+// Wind Conversion
+
+// To convert between miles per hour (mph) and knots (kts)
+double mph2kts( double mph );
+double kts2mph( double kts );
+
+// To convert between miles per hour (mph) and meters per second (m/s)
+double mph2mps( double mph );
+double mps2mph( double mps );
+
+// To convert between miles per hour (mph) and feet per second (ft/s)
+double fps2mph( double fps );
+double mph2fps( double mph );
+
+// To convert between miles per hours (mph) and kilometers per hour (km/h): 
+double mph2kph( double kph );
+double kph2mph( double mph );
+
+// To convert between knots (kts) and meters per second (m/s)
+double kts2mps( double kts );
+double mps2kts( double mps );
+
+
+// To convert between knots (kts) and feet per second (ft/s)
+double fps2kts( double fps );
+double kts2fps( double kts );
+
+// To convert between knots (kts) and kilometers per hour (km/h)
+double kph2kts( double kph );
+double kts2kph( double kts );
+
+// To convert between meters per second (m/s) and feet per second (ft/s):
+double mps2fps( double fps );
+double fps2mps( double mps );
+
+// To convert between meters per second (m/s) and kilometers per hour (km/h):
+double kph2mps( double kph );
+double mps2kph( double mps );
+
+// To convert between feet per second (ft/s) and kilometers per hours (km/h)
+double fps2kph( double fps );
+double kph2fps( double kph );
+
+// Convert meter to feet
+double ft2m( double ft );
+double m2ft( double m );
+
+// Temperature Conversions
+
+// To convert between degrees Fahrenheit and degrees Celsius 
+double F2C( double F );
+double C2F( double C );
+
+//  To convert between degrees Fahrenheit and Kelvin
+double K2F( double K );
+double F2K( double F );
+
+// To convert between degrees Fahrenheit to Rankine 
+double R2F( double R );
+double F2R( double F );
+
+// To convert between degrees Celsius to Kelvin 
+double K2C( double K );
+double C2K( double C );
+
+// To convert between degrees Celsius to Rankine
+double R2C( double R );
+double C2R( double C );
+
+// To convert between Kevin and Rankine 
+double R2K( double R );
+double K2R( double K );
+
+// Rain rate conversions
+double in2mm( double in );
+double mm2in( double mm );
+
+double inHg2hPa( double inHg );
+double hPa2inHg( double hPa );
+
+
+// Trig
+
+float deg2rad( float deg );
+float rad2deg( float rad );
+
+
+// Time
+int jan1local();
+time_t gmt2local( time_t gmt );
+time_t julian2localtime( double dec );
+
+
+// Math
+double frac( double num );
+
+// Geography
+// AACHEN: Function signature changed to avoid returning std::string.
+char* DecimalLatitudeToLORAN( double decimalDegrees );
+char* DecimalLongitudeToLORAN( double decimalDegrees );
+
+#endif // __UNITS_H__
+


### PR DESCRIPTION
I don't understand how this benchmark could have ever worked. It does not compile. Even if I drop in the missing header file (with the additional function signature changes) and fix up the paths it will not compile due to uses of `bool` in C code.

This benchmark also seems to call `DecimalLatitudeToLORAN()` and `DecimalLongitudeToLORAN()` for no apparent reason.

