### PR TITLE
Remove wrong `issta_2017` tag that I accidently added

### DIFF
--- a/real/units/spec.yml
+++ b/real/units/spec.yml
@@ -2,7 +2,6 @@ architectures:
   - x86_64
 categories:
   - real_world
-  - issta_2017
   - aachen
 dependencies:
   cmath: {}
@@ -43,6 +42,8 @@ runtime_environment:
     'UNITSFILE': '@spec_dir@units-2.13/definitions.units'
 variants:
   meter_ft:
+    categories:
+      - issta_2017
     defines:
       KLEE: null
     dependencies:


### PR DESCRIPTION
Remove wrong `issta_2017` tag that I accidently added to
`units_meter_ft_non_klee` in 1964a164985cc3e0c9e264a004be83969a94a937

The `units_meter_ft_non_klee` benchmark is not supposed to be part
of our study. It is only for testing.