### PR TITLE
Remove undefined division by zero behaviour in `gmp_klee_inv_arg.x86_64`

### DIFF
--- a/real/gmp/benchmarks/gmp-6.1.1/errno.c
+++ b/real/gmp/benchmarks/gmp-6.1.1/errno.c
@@ -50,7 +50,7 @@ void
 __gmp_exception (int error_bit)
 {
   gmp_errno |= error_bit;
-  __gmp_junk = 10 / __gmp_0;
+  // __gmp_junk = 10 / __gmp_0; // DL: Disable due to UB which might get removed by Clang.
   abort ();
 }
 

--- a/real/gmp/benchmarks/spec.yml
+++ b/real/gmp/benchmarks/spec.yml
@@ -56,16 +56,10 @@ variants:
                 description: 'first method of abortion'
                 file: 'gmp-6.1.1/invalid.c'
                 line: 82
-      no_integer_division_by_zero:
-        correct: false
-        counter_examples:
-          -
-            description: 'Expected Error'
-            locations:
               -
                 description: 'second method of abortion'
                 file: 'gmp-6.1.1/errno.c'
-                line: 53
+                line: 54
   klee_integer:
     defines:
       KLEE: null


### PR DESCRIPTION
Remove undefined division by zero behaviour in `gmp_klee_inv_arg.x86_64` and adjust spec to expect calling abort instead.

Although the division by zero bug is a real bug a compiler is free to do
whatever it wants due to this being undefined behaviour.

It has been observed that running some LLVM passes removes the operation
and at execution time this causes the `abort()` immediately after to be
called.

Although it would be nice to have a "division by zero bug" in our
benchmark suite it has been agreed that in this case reaching the
`abort()` should be allowed and therefore we need to remove the
division by zero operation.